### PR TITLE
Add Input Clearing prior to asking for input

### DIFF
--- a/google-photos-takeout.sh
+++ b/google-photos-takeout.sh
@@ -73,6 +73,11 @@ mv "$fullpaths.tmp" "$fullpaths"
 # print fullpaths size
 echo "Found $(wc -l < "$fullpaths") unique files to process"
 
+# Clear any previous input before the "read" command
+while read -t 0.1 -r -n 10000; do
+  continue
+done
+
 # ask for confirmation
 read -p "Looks correct? [y/N] " -n 1 -r
 printf "\n"
@@ -96,6 +101,11 @@ exiftool \
   -preserve \
   -progress \
   -@ "$fullpaths" || true
+
+# Clear any previous input before the "read" command
+while read -t 0.1 -r -n 10000; do
+  continue
+done
 
 # optional cleanup JSON files
 read -p "Delete all JSON files? [y/N] " -n 1 -r


### PR DESCRIPTION
Added blocks to clear input before asking if everything is correct. This allows impatient people with large libraries to accidentally press a key during the pre-processing and not lose their entire run inadvertently.